### PR TITLE
Use composition rather than inheritance for the YamlLoader

### DIFF
--- a/Player/Loader/LoaderInterface.php
+++ b/Player/Loader/LoaderInterface.php
@@ -19,6 +19,8 @@ use Blackfire\Player\Scenario;
 interface LoaderInterface
 {
     /**
+     * @param mixed $data
+     *
      * @return Scenario
      */
     public function load($data);

--- a/Player/Loader/YamlLoader.php
+++ b/Player/Loader/YamlLoader.php
@@ -17,13 +17,15 @@ use Symfony\Component\Yaml\Parser as YamlParser;
 /**
  * @author Fabien Potencier <fabien@blackfire.io>
  */
-class YamlLoader extends ArrayLoader
+class YamlLoader implements LoaderInterface
 {
     private $parser;
+    private $arrayLoader;
 
     public function __construct()
     {
         $this->parser = new YamlParser();
+        $this->arrayLoader = new ArrayLoader();
     }
 
     public function load($yaml)
@@ -38,6 +40,6 @@ class YamlLoader extends ArrayLoader
             throw new LoaderException(sprintf('YAML scenarios must be defined under the "scenario" or "scenario" key.'));
         }
 
-        return parent::load($data);
+        return $this->arrayLoader->load($data);
     }
 }


### PR DESCRIPTION
The YamlLoader is not a specialized ArrayLoader. It does not accept the same kind of input, breaking the principle of inheritance.
Using the ArrayLoader through composition avoids this issue.