### PR TITLE
Enable debug mode in guzzle when -vvv

### DIFF
--- a/Player/Console/PlayerCommand.php
+++ b/Player/Console/PlayerCommand.php
@@ -21,6 +21,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 
@@ -52,9 +53,9 @@ EOF
     {
         $logger = new ConsoleLogger($output);
 
-        $clients = [$this->createClient($output->isDebug())];
+        $clients = [$this->createClient($output)];
         for ($i = 1; $i < $input->getOption('concurrency'); ++$i) {
-            $clients[] = $this->createClient($output->isDebug());
+            $clients[] = $this->createClient($output);
         }
 
         $player = new Player($clients);
@@ -113,11 +114,14 @@ EOF
         }
     }
 
-    private function createClient($isDebug = false)
+    private function createClient(OutputInterface $output)
     {
         return new GuzzleClient([
             'cookies' => true,
-            'debug' => $isDebug,
+            'debug' => $output->isDebug() && $output instanceof ConsoleOutput
+                ? $output->getErrorOutput()->getStream()
+                : false
+            ,
         ]);
     }
 }

--- a/Player/Console/PlayerCommand.php
+++ b/Player/Console/PlayerCommand.php
@@ -52,9 +52,9 @@ EOF
     {
         $logger = new ConsoleLogger($output);
 
-        $clients = [$this->createClient()];
+        $clients = [$this->createClient($output->isDebug())];
         for ($i = 1; $i < $input->getOption('concurrency'); ++$i) {
-            $clients[] = $this->createClient();
+            $clients[] = $this->createClient($output->isDebug());
         }
 
         $player = new Player($clients);
@@ -113,10 +113,11 @@ EOF
         }
     }
 
-    private function createClient()
+    private function createClient($isDebug = false)
     {
         return new GuzzleClient([
             'cookies' => true,
+            'debug' => $isDebug,
         ]);
     }
 }

--- a/Player/Console/PlayerCommand.php
+++ b/Player/Console/PlayerCommand.php
@@ -116,12 +116,11 @@ EOF
 
     private function createClient(OutputInterface $output)
     {
+        $debug = $output->isDebug() && $output instanceof ConsoleOutput ? $output->getErrorOutput()->getStream() : false;
+
         return new GuzzleClient([
             'cookies' => true,
-            'debug' => $output->isDebug() && $output instanceof ConsoleOutput
-                ? $output->getErrorOutput()->getStream()
-                : false
-            ,
+            'debug' => $debug,
         ]);
     }
 }


### PR DESCRIPTION
Hi !

Why not to use [debug guzzle mode](http://guzzle.readthedocs.org/en/latest/request-options.html?highlight=debug#debug) when we use ``-vvv`` verbosity level ? It's realy useful to develop/debug scenarios.

Before :

```
$ blackfire-player run debug.yml -vvv
[debug] Concurrency set to "1"
[info] Starting scenario "Homepage" (sent to client 0)
[info] Step 1: Homepage GET http://localhost/
[debug] Expectation "status_code() == 200" pass
```

After :

```diff
$ blackfire-player run debug.yml -vvv
[debug] Concurrency set to "1"
[info] Starting scenario "Homepage" (sent to client 0)
[info] Step 1: Homepage GET http://localhost/
+* Hostname was NOT found in DNS cache
+*   Trying 127.0.0.1...
+* Connected to localhost (127.0.0.1) port 80 (#0)
+> GET / HTTP/1.1
+User-Agent: GuzzleHttp/6.1.1 curl/7.35.0 PHP/5.6.16-2+deb.sury.org~trusty+1
+Host: localhost
+Content-Type: application/x-www-form-urlencoded
+X-Request-Id: f6c97a7
+
+< HTTP/1.1 200 OK
+< Date: Tue, 22 Dec 2015 16:51:53 GMT
+* Server Apache/2.4.7 (Ubuntu) is not blacklisted
+< Server: Apache/2.4.7 (Ubuntu)
+< Vary: Accept-Encoding
+< Content-Length: 7867
+< Content-Type: text/html;charset=UTF-8
+< 
+* Connection #0 to host localhost left intact
[debug] Expectation "status_code() == 200" pass
```