### PR TITLE
Documentation: fixed missing visit keywords

### DIFF
--- a/docs/crawling.rst
+++ b/docs/crawling.rst
@@ -291,7 +291,7 @@ Embedding Scenarios with ``add``
               steps:
                   - add: login
 
-                  - url('/admin')
+                  - visit: url('/admin')
                     expect:
                         - status_code() == 200
 
@@ -574,7 +574,7 @@ login, account creation, or deletion steps, ...):
               steps:
                   - add: login
 
-                  - url('/stats')
+                  - visit: url('/stats')
 
                   # ...
 
@@ -583,7 +583,7 @@ login, account creation, or deletion steps, ...):
               steps:
                   - add: login
 
-                  - url('/admin/')
+                  - visit: url('/admin/')
 
                   # ...
 


### PR DESCRIPTION
It looks like some `visit:` keywords were missing before calling `url()` so this could not work actually.