### PR TITLE
Fix embedding scenarios bug

### DIFF
--- a/Player/Scenario.php
+++ b/Player/Scenario.php
@@ -50,7 +50,7 @@ class Scenario
         $this->root = clone $scenario->getRoot();
         $this->root->setOptions($options);
 
-        return $this->root;
+        return $this->root->getLast();
     }
 
     public function header($key, $value)


### PR DESCRIPTION
Hi !

It's impossible to execute multiple steps in embedded scenario. For example, if you have :

```yml
scenarios:
    - options:
          key: sub
      steps:
          - title: A
            visit: url('/?a')
          - title: B
            visit: url('/?b')
    - options:
          title: main
      steps:
          - add: sub
          - title: C
            visit: url('/?c')
```

The result is :

```
[info] Starting scenario "main" (sent to client 0)
[info] Step 1: A GET http://localhost:8080?a
[info] Step 2: C GET http://localhost:8080?c
```

And with this PR :

```diff
[info] Starting scenario "main" (sent to client 0)
[info] Step 1: A GET http://localhost:8080?a
+ [info] Step 2: B GET http://localhost:8080?b
[info] Step 3: C GET http://localhost:8080?c
```

