### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/Player/Tests/Extension/BlackfireExtensionTest.php
+++ b/Player/Tests/Extension/BlackfireExtensionTest.php
@@ -23,9 +23,10 @@ use Blackfire\Profile;
 use Blackfire\Profile\Request as ProfileRequest;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\NullOutput;
 
-class BlackfireExtensionTest extends \PHPUnit_Framework_TestCase
+class BlackfireExtensionTest extends TestCase
 {
     /**
      * @dataProvider stepsProvider

--- a/Player/Tests/Extension/WatchdogExtensionTest.php
+++ b/Player/Tests/Extension/WatchdogExtensionTest.php
@@ -14,10 +14,11 @@ namespace Player\Tests;
 use Blackfire\Player\Context;
 use Blackfire\Player\Extension\WatchdogExtension;
 use Blackfire\Player\Step\ConfigurableStep;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
-class WatchdogExtensionTest extends \PHPUnit_Framework_TestCase
+class WatchdogExtensionTest extends TestCase
 {
     public function testStepLimitResetWhenStepIsExpectedOne()
     {

--- a/Player/Tests/ParserTest.php
+++ b/Player/Tests/ParserTest.php
@@ -17,8 +17,9 @@ use Blackfire\Player\Scenario;
 use Blackfire\Player\ScenarioSet;
 use Blackfire\Player\Step\ReloadStep;
 use Blackfire\Player\Step\VisitStep;
+use PHPUnit\Framework\TestCase;
 
-class ParserTest extends \PHPUnit_Framework_TestCase
+class ParserTest extends TestCase
 {
     public function testParsingSeparatedScenario()
     {

--- a/Player/Tests/PlayerTest.php
+++ b/Player/Tests/PlayerTest.php
@@ -14,13 +14,14 @@ namespace Player\Tests;
 use Blackfire\Player\Console\Application;
 use Blackfire\Player\Player;
 use Blackfire\Player\Scenario;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\ProcessBuilder;
 
-class PlayerTest extends \PHPUnit_Framework_TestCase
+class PlayerTest extends TestCase
 {
     private static $port;
     private static $server;

--- a/Player/Tests/Psr7/RequestGeneratorTest.php
+++ b/Player/Tests/Psr7/RequestGeneratorTest.php
@@ -25,10 +25,11 @@ use Blackfire\Player\Step\LoopStep;
 use Blackfire\Player\Step\ReloadStep;
 use Blackfire\Player\Step\VisitStep;
 use Blackfire\Player\Step\WhileStep;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
-class RequestGeneratorTest extends \PHPUnit_Framework_TestCase
+class RequestGeneratorTest extends TestCase
 {
     private $language;
     private $stepConverter;

--- a/composer.lock
+++ b/composer.lock
@@ -1430,16 +1430,16 @@
         },
         {
             "name": "symfony/phpunit-bridge",
-            "version": "v3.3.9",
+            "version": "v3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/phpunit-bridge.git",
-                "reference": "27d159bd9bd14a3bd9d3e136081c321a0d621c03"
+                "reference": "9ecf83a2628b4668f02e680f65357c62600749fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/27d159bd9bd14a3bd9d3e136081c321a0d621c03",
-                "reference": "27d159bd9bd14a3bd9d3e136081c321a0d621c03",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/9ecf83a2628b4668f02e680f65357c62600749fc",
+                "reference": "9ecf83a2628b4668f02e680f65357c62600749fc",
                 "shasum": ""
             },
             "require": {
@@ -1458,7 +1458,7 @@
             "type": "symfony-bridge",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -1488,7 +1488,7 @@
             ],
             "description": "Symfony PHPUnit Bridge",
             "homepage": "https://symfony.com",
-            "time": "2017-09-05T11:23:06+00:00"
+            "time": "2017-12-04T20:23:06+00:00"
         },
         {
             "name": "symfony/process",


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit\Framework\TestCase` while extending our TestCases. This will help us when migrating to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/6.0/ChangeLog-6.0.md#changed-1).