### PR TITLE
set correct filename for groups

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -312,7 +312,7 @@ Embedding Scenarios with ``include``
 ``include`` allows to embed some repetitive steps into several scenarios to
 avoid copy/pasting the same code over and over again:
 
-In a ``login.bkf`` file, write a ``group`` that contains the logic to log in:
+In a ``groups.bkf`` file, write a ``group`` that contains the logic to log in:
 
 .. code-block:: blackfire
 


### PR DESCRIPTION
It is confusing that the doc says to create a group in a `login.bkf` file then, `load` a `groups.bkf` that does not exists. 
