### PR TITLE
Add variables into multiline strings

### DIFF
--- a/Player/Input.php
+++ b/Player/Input.php
@@ -143,7 +143,7 @@ final class Input
 
                 $escaped = ' ' . $this->escapeValue($val);
                 if (\in_array('i', $modifiers, true)){
-                    $lines[$current] .= preg_replace('/(?<!\\\\)\\$\{\s*(\w+)\s*\}/', "' ~ $1 ~ '", $escaped);
+                    $lines[$current] .= preg_replace('/(?<!\\\\)\\$\{\s*(' . Parser::REGEX_NAME . ')\s*\}/', "' ~ $1 ~ '", $escaped);
                 } else {
                     $lines[$current] .= $escaped;
                 }

--- a/Player/Input.php
+++ b/Player/Input.php
@@ -118,7 +118,7 @@ final class Input
         while (null !== $line = array_shift($input)) {
             ++$lineno;
 
-            if (preg_match('/^(\s*)"""([i]*)$/', $line, $matches)) { // Start multi-lines
+            if (preg_match('/^(\s*)"""(i)?$/', $line, $matches)) { // Start multi-lines
                 $modifiers = str_split(\ltrim($line, ' "'), 1);
                 $indent = $matches[1];
                 $val = '';

--- a/Player/Input.php
+++ b/Player/Input.php
@@ -118,7 +118,8 @@ final class Input
         while (null !== $line = array_shift($input)) {
             ++$lineno;
 
-            if (preg_match('/^(\s*)"""$/', $line, $matches)) { // Start multi-lines
+            if (preg_match('/^(\s*)"""([i]*)$/', $line, $matches)) { // Start multi-lines
+                $modifiers = str_split(\ltrim($line, ' "'), 1);
                 $indent = $matches[1];
                 $val = '';
                 while (null !== $line = array_shift($input)) {
@@ -140,7 +141,12 @@ final class Input
                     $val .= substr($line, \strlen($indent))."\n";
                 }
 
-                $lines[$current] .= ' '.$this->escapeValue($val);
+                $escaped = ' ' . $this->escapeValue($val);
+                if (\in_array('i', $modifiers, true)){
+                    $lines[$current] .= preg_replace('/(?<!\\\\)\\$\{\s*(\w+)\s*\}/', "' ~ $1 ~ '", $escaped);
+                } else {
+                    $lines[$current] .= $escaped;
+                }
 
                 continue;
             }

--- a/Player/Tests/ParserTest.php
+++ b/Player/Tests/ParserTest.php
@@ -695,11 +695,12 @@ set multi
 ${ variable }
 ${variable}
 ${ someCamelCase }
+${ some_snake_123 }
 """
 EOF
         );
 
-        $expected = '\'\' ~ variable ~ \'\n\' ~ variable ~ \'\n\' ~ someCamelCase ~ \'\'';
+        $expected = '\'\' ~ variable ~ \'\n\' ~ variable ~ \'\n\' ~ someCamelCase ~ \'\n\' ~ some_snake_123 ~ \'\'';
         $this->assertEquals($expected, $scenarioSet->getVariables()['multi']);
     }
 

--- a/README.rst
+++ b/README.rst
@@ -264,7 +264,8 @@ You can also pass a Request body:
                 }
                 """
 
-    Starting from version v1.11.0 you can also use variables by adding `i` option to multiline string.
+    Starting from version v1.11.0 you can also use variables by adding ``i`` option to multiline string.
+
     .. code-block:: blackfire
 
         scenario

--- a/README.rst
+++ b/README.rst
@@ -264,6 +264,22 @@ You can also pass a Request body:
                 }
                 """
 
+    Starting from version v1.11.0 you can also use variables by adding `i` option to multiline string.
+    .. code-block:: blackfire
+
+        scenario
+            visit url('/login')
+                method 'POST'
+                set username "john"
+                set password "doe"
+                body
+                """i
+                {
+                    "user": "${username}",
+                    "password": "${password}"
+                }
+                """
+
 .. _clicking-on-a-link-with-click:
 
 Clicking on a Link with ``click``


### PR DESCRIPTION
### Current state:
Multiline strings allow to easily use JSON for the requests but there is no way to use variable to set same specific key. 

### Idea:
We can use similar syntax as in Twig: `{{ variableName }}`, to use variable inside multiline variable. 

### Example:
```
set login admin
set password qwerty

scenario Test 1
    visit url('/')
        body
        """
        {
            login: "{{login}}",
            password: "{{password}}"
        }
        """
```
Will send body like:
```
{
    login: "admin",
    password: "qwerty"
}
```