### PR TITLE
Allow to specify a custom Content-Type header

### DIFF
--- a/Player/StepProcessor/VisitStepProcessor.php
+++ b/Player/StepProcessor/VisitStepProcessor.php
@@ -55,13 +55,13 @@ class VisitStepProcessor implements StepProcessorInterface
         $headers = $this->expressionEvaluator->evaluateHeaders($stepContext, $scenarioContext);
         if (null === $body = $step->getBody()) {
             if ($this->expressionEvaluator->evaluateExpression($stepContext->isJson(), $stepContext, $scenarioContext)) {
-                $headers['content-type'] = [Request::CONTENT_TYPE_JSON];
+                $headers['content-type'] ??= [Request::CONTENT_TYPE_JSON];
             } else {
-                $headers['content-type'] = [Request::CONTENT_TYPE_FORM];
+                $headers['content-type'] ??= [Request::CONTENT_TYPE_FORM];
             }
             $body = $this->expressionEvaluator->evaluateValues($step->getParameters(), $stepContext, $scenarioContext);
         } else {
-            $headers['content-type'] = [Request::CONTENT_TYPE_RAW];
+            $headers['content-type'] ??= [Request::CONTENT_TYPE_RAW];
             $body = $this->expressionEvaluator->evaluateExpression($body, $stepContext, $scenarioContext);
         }
 

--- a/Player/Tests/StepProcessor/VisitStepProcessorTest.php
+++ b/Player/Tests/StepProcessor/VisitStepProcessorTest.php
@@ -118,6 +118,7 @@ class VisitStepProcessorTest extends TestCase
     public function provideForTestProcessPreserveHeaders(): iterable
     {
         yield 'Authorization header' => ['Authorization', 'Bearer foo:bar'];
+        yield 'Content-Type header' => ['Content-Type', 'application/custom'];
     }
 
     private function createProcessor(): StepProcessorInterface

--- a/Player/Tests/StepProcessor/VisitStepProcessorTest.php
+++ b/Player/Tests/StepProcessor/VisitStepProcessorTest.php
@@ -97,13 +97,14 @@ class VisitStepProcessorTest extends TestCase
         $this->assertSame(['foo' => 'bar'], $nextStep->getRequest()->body);
     }
 
-    public function testProcessPreserveHeaders()
+    /** @dataProvider provideForTestProcessPreserveHeaders */
+    public function testProcessPreserveHeaders(string $headerName, string $headerValue)
     {
         $processor = $this->createProcessor();
         $scenarioContext = new ScenarioContext('"foo"', new ScenarioSet());
 
         $step = new VisitStep('"http://localhost"');
-        $step->header('"Authorization: Bearer foo:bar"');
+        $step->header(sprintf('"%s: %s"', $headerName, $headerValue));
         $stepContext = new StepContext();
         $stepContext->update($step, []);
 
@@ -111,7 +112,12 @@ class VisitStepProcessorTest extends TestCase
         $this->assertCount(1, $nextSteps);
         $nextStep = $nextSteps[0];
         $this->assertInstanceOf(RequestStep::class, $nextStep);
-        $this->assertSame('Bearer foo:bar', $nextStep->getRequest()->headers['authorization'][0]);
+        $this->assertSame($headerValue, $nextStep->getRequest()->headers[strtolower($headerName)][0]);
+    }
+
+    public function provideForTestProcessPreserveHeaders(): iterable
+    {
+        yield 'Authorization header' => ['Authorization', 'Bearer foo:bar'];
     }
 
     private function createProcessor(): StepProcessorInterface


### PR DESCRIPTION
Possible fix for https://github.com/blackfireio/player/issues/75

My suggestion is to not overwrite the Content-Type header if it has been specified directly in the tests.

To make things easier it should be possible to review this by commits:
1) Refactors the code to add a new test case
2) Adds a failing tests
3) Changed the program so that the new test is now passing